### PR TITLE
WIP: Update to use Packets instead of Res

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -48,3 +48,7 @@ export let randInt = (lo: number, hi: number): number =>
 
 export let makeId = (): string =>
     ('' + randInt(0, 999999999999999)).padStart(15, '0');
+    
+export let isGenerator = (fn: any) =>
+    ["GeneratorFunction", "AsyncGeneratorFunction"]
+        .includes(fn.constructor.name);

--- a/src/test/things-to-test.ts
+++ b/src/test/things-to-test.ts
@@ -44,6 +44,42 @@ export let myFunctions = {
     hello: (name: string) => { return `Hello ${name}`; },
     throwMyError: () => { throw new MyError('text of error'); },
     throwMyError2: () => { throw new MyError2('text of error2'); },
+    generator0: async function* () {
+        for (let ii = 0; ii <= 999; ii++) {
+              if (ii > 5) {
+                break;
+              }
+              await sleep(100);
+              yield ii;
+            }
+    },
+    generator1: async function* (max: number) {
+        for (let ii = 0; ii <= max; ii++) {
+              if (ii > 5) {
+                break;
+              }
+              await sleep(100);
+              yield ii;
+            }
+    },
+    generator2: async function* (max: number, limit: number) {
+        for (let ii = 0; ii <= max; ii++) {
+              if (ii > limit) {
+                break;
+              }
+              await sleep(100);
+              yield ii;
+            }
+    },
+    generatorError: async function* () {
+        for (let ii = 0; ii <= 999; ii++) {
+              if (ii > 5) {
+                throw new MyError("can't count higher than 5");
+              }
+              await sleep(100);
+              yield ii;
+            }
+    },
 };
 
 export class MyClass {
@@ -73,4 +109,41 @@ export class MyClass {
     hello(name: string) { return `Hello ${name}`; }
     throwMyError() { throw new MyError('text of error'); }
     throwMyError2() { throw new MyError2('text of error2'); }
+    
+    async * generator0 () {
+        for (let ii = 0; ii <= 999; ii++) {
+              if (ii > 5) {
+                break;
+              }
+              await sleep(100);
+              yield ii;
+            }
+    }
+    async * generator1 (max: number) {
+        for (let ii = 0; ii <= max; ii++) {
+              if (ii > 5) {
+                break;
+              }
+              await sleep(100);
+              yield ii;
+            }
+    }
+    async * generator2 (max: number, limit: number) {
+        for (let ii = 0; ii <= max; ii++) {
+              if (ii > limit) {
+                break;
+              }
+              await sleep(100);
+              yield ii;
+            }
+    }
+    async * generatorError () {
+        for (let ii = 0; ii <= 999; ii++) {
+              if (ii > 5) {
+                throw new MyError("can't count higher than 5");
+              }
+              await sleep(100);
+              yield ii;
+            }
+    }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
This is an experiment to use @cinnamon-bun's cool approach of adding streaming behaviour to mini-rpc with async generators. All I've done is formalised what was sketched out in [this proof of concept](https://github.com/earthstar-project/mini-rpc/blob/stream-ideas/src/stream-ideas.ts).

I think this is a very elegant, idiomatic approach! It was way less of a rework than I expected.

## Changes

- Updated `evaluator` to be a generator returning `Packet` values
- Updated `makeProxy` to handle the new generator style evaluator
- Updated tests in mini-rpc.test.ts, all passing
- Made it so that the proxy can automatically detect generator methods, so no special naming needed

## Not yet done

- Haven't updated any of the http related evaluators / tests yet.